### PR TITLE
Install icons by default on macOS too

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(qt_gui_icons)
 
 find_package(ament_cmake REQUIRED)
 
-if (WIN32 OR INSTALL_QT_GUI_ICONS)
+if (WIN32 OR APPLE OR INSTALL_QT_GUI_ICONS)
   install(DIRECTORY resource
     DESTINATION share/${PROJECT_NAME})
 endif()


### PR DESCRIPTION
Installing Icons by default on mac to reduce the logic in qt_gui_core/qt_gui.

Icons can be installed on MacOS with brew as described [here](https://github.com/ros-visualization/rqt/issues/165#issuecomment-447483546), but this will require different logic for mac and windows.

Signed-off-by: ahcorde <ahcorde@gmail.com>